### PR TITLE
Make the MVdW Placeholder Request event have more logic

### DIFF
--- a/src/main/java/io/github/apickledwalrus/placeholderaddon/skript/events/EvtMvdwPlaceholderRequest.java
+++ b/src/main/java/io/github/apickledwalrus/placeholderaddon/skript/events/EvtMvdwPlaceholderRequest.java
@@ -26,7 +26,7 @@ public class EvtMvdwPlaceholderRequest extends SkriptEvent {
 
 	static {
 		if (Main.hasMVdW()) {
-			Skript.registerEvent("Placeholder Request", EvtMvdwPlaceholderRequest.class, MvdwAPIEvent.class, "mvdw[ ](placeholderapi placeholder|placeholder) request (for|with) [the] placeholder %string%");
+			Skript.registerEvent("Placeholder Request", EvtMvdwPlaceholderRequest.class, MvdwAPIEvent.class, "[on] mvdw[ ](placeholderapi [placeholder]|placeholder) request (for|with) [the] placeholder %string%");
 			EventValues.registerEventValue(MvdwAPIEvent.class, Player.class, new Getter<Player, MvdwAPIEvent>() {
 				@Override
 				public Player get(MvdwAPIEvent e) {


### PR DESCRIPTION
1. It can now be fired with 'on', the keyword every event has as optional.
2. The placeholder at 'placeholderapi placeholder' is now optional to match the syntax of the PAPI event better.
Small QoL change, not really necessary.