### PR TITLE
Support Object When Setting Placeholder Result

### DIFF
--- a/src/main/java/io/github/apickledwalrus/skriptplaceholders/skript/elements/ExprPlaceholderResult.java
+++ b/src/main/java/io/github/apickledwalrus/skriptplaceholders/skript/elements/ExprPlaceholderResult.java
@@ -11,6 +11,7 @@ import ch.njol.skript.lang.Expression;
 import ch.njol.skript.lang.ExpressionType;
 import ch.njol.skript.lang.SkriptParser.ParseResult;
 import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.skript.registrations.Classes;
 import ch.njol.util.Kleenean;
 import ch.njol.util.coll.CollectionUtils;
 import io.github.apickledwalrus.skriptplaceholders.skript.PlaceholderEvent;
@@ -56,6 +57,7 @@ public class ExprPlaceholderResult extends SimpleExpression<String> {
 	public Class<?>[] acceptChange(ChangeMode mode) {
 		switch (mode) {
 			case SET:
+				return CollectionUtils.array(Object.class);
 			case DELETE:
 			case RESET:
 				return CollectionUtils.array(String.class);
@@ -66,13 +68,18 @@ public class ExprPlaceholderResult extends SimpleExpression<String> {
 
 	@Override
 	public void change(Event event, @Nullable Object[] delta, ChangeMode mode) {
+		PlaceholderEvent placeholderEvent = ((PlaceholderEvent) event);
 		switch (mode) {
 			case SET:
-				((PlaceholderEvent) event).setResult((String) delta[0]);
+				if (delta[0] instanceof String) {
+					placeholderEvent.setResult((String) delta[0]);
+					break;
+				}
+				placeholderEvent.setResult(Classes.toString(delta[0]));
 				break;
 			case RESET:
 			case DELETE:
-				((PlaceholderEvent) event).setResult(null);
+				placeholderEvent.setResult(null);
 				break;
 			default:
 				assert false;

--- a/src/main/java/io/github/apickledwalrus/skriptplaceholders/skript/elements/ExprPlaceholderResult.java
+++ b/src/main/java/io/github/apickledwalrus/skriptplaceholders/skript/elements/ExprPlaceholderResult.java
@@ -28,7 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
 		"\t# Placeholder is \"{skriptplaceholders_author}\"",
 		"\tset the result to \"APickledWalrus\""
 })
-@Since("1.0, 1.3 (MVdWPlaceholderAPI support)")
+@Since("1.0, 1.3 (MVdWPlaceholderAPI support), INSERT VERSION (object support)")
 @Events("Placeholder Request")
 public class ExprPlaceholderResult extends SimpleExpression<String> {
 

--- a/src/main/java/io/github/apickledwalrus/skriptplaceholders/skript/elements/ExprPlaceholderResult.java
+++ b/src/main/java/io/github/apickledwalrus/skriptplaceholders/skript/elements/ExprPlaceholderResult.java
@@ -57,10 +57,9 @@ public class ExprPlaceholderResult extends SimpleExpression<String> {
 	public Class<?>[] acceptChange(ChangeMode mode) {
 		switch (mode) {
 			case SET:
-				return CollectionUtils.array(Object.class);
 			case DELETE:
 			case RESET:
-				return CollectionUtils.array(String.class);
+				return CollectionUtils.array(Object.class);
 			default:
 				return null;
 		}
@@ -73,9 +72,9 @@ public class ExprPlaceholderResult extends SimpleExpression<String> {
 			case SET:
 				if (delta[0] instanceof String) {
 					placeholderEvent.setResult((String) delta[0]);
-					break;
+				} else {
+					placeholderEvent.setResult(Classes.toString(delta[0]));
 				}
-				placeholderEvent.setResult(Classes.toString(delta[0]));
 				break;
 			case RESET:
 			case DELETE:


### PR DESCRIPTION
This PR adds support for using any other than String when setting the placeholder result:
```py
on papi request for the prefix "test":
  if identifier = "skript_date":
    set result to now
  else if identifier = "rng":
    set result to random number between 0 and 127
```